### PR TITLE
Fall back to memory-efficient algorithm when performing cuda spgemm

### DIFF
--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -2505,25 +2505,63 @@ void spgemm(std::shared_ptr<const DefaultExecutor> exec,
     auto c_descr = sparselib::create_csr(m, n, zero_nnz, c_row_ptrs, null_index,
                                          null_value);
 
-    // estimate work
-    size_type buffer1_size{};
-    sparselib::spgemm_work_estimation(handle, &alpha, a_descr, b_descr, &beta,
-                                      c_descr, spgemm_descr, buffer1_size,
-                                      nullptr);
-    array<char> buffer1{exec, buffer1_size};
-    sparselib::spgemm_work_estimation(handle, &alpha, a_descr, b_descr, &beta,
-                                      c_descr, spgemm_descr, buffer1_size,
-                                      buffer1.get_data());
+    auto spgemm_alg = CUSPARSE_SPGEMM_ALG1;
 
-    // compute spgemm
+    size_type buffer1_size{};
     size_type buffer2_size{};
-    sparselib::spgemm_compute(handle, &alpha, a_descr, b_descr, &beta, c_descr,
-                              spgemm_descr, buffer1.get_data(), buffer2_size,
-                              nullptr);
-    array<char> buffer2{exec, buffer2_size};
-    sparselib::spgemm_compute(handle, &alpha, a_descr, b_descr, &beta, c_descr,
-                              spgemm_descr, buffer1.get_data(), buffer2_size,
-                              buffer2.get_data());
+    array<char> buffer1{exec};
+    array<char> buffer2{exec};
+
+    // Try CUSPARSE_SPGEMM_ALG1 first as it is fastest for small matrices
+    try {
+        // Memory estimate for Alg1
+        sparselib::spgemm_work_estimation(handle, &alpha, a_descr, b_descr,
+                                          &beta, c_descr, spgemm_descr,
+                                          spgemm_alg, buffer1_size, nullptr);
+        buffer1.resize_and_reset(buffer1_size);
+        sparselib::spgemm_work_estimation(
+            handle, &alpha, a_descr, b_descr, &beta, c_descr, spgemm_descr,
+            spgemm_alg, buffer1_size, buffer1.get_data());
+        sparselib::spgemm_compute(handle, &alpha, a_descr, b_descr, &beta,
+                                  c_descr, spgemm_descr, spgemm_alg,
+                                  buffer1.get_data(), buffer2_size, nullptr);
+        // compute spgemm
+        buffer2.resize_and_reset(buffer2_size);
+        sparselib::spgemm_compute(
+            handle, &alpha, a_descr, b_descr, &beta, c_descr, spgemm_descr,
+            spgemm_alg, buffer1.get_data(), buffer2_size, buffer2.get_data());
+    }
+
+    catch (const CusparseError& cse) {
+        // If estimated buffer size is too large and CUDA > 12.0,  fall back to
+        // ALG2
+#if CUDA_VERSION >= 12000
+        spgemm_alg = CUSPARSE_SPGEMM_ALG2;
+        // Memory estimate for Alg2/Alg3
+        sparselib::spgemm_work_estimation(handle, &alpha, a_descr, b_descr,
+                                          &beta, c_descr, spgemm_descr,
+                                          spgemm_alg, buffer1_size, nullptr);
+        buffer1.resize_and_reset(buffer1_size);
+        sparselib::spgemm_work_estimation(
+            handle, &alpha, a_descr, b_descr, &beta, c_descr, spgemm_descr,
+            spgemm_alg, buffer1_size, buffer1.get_data());
+        size_type buffer3_size{};
+        sparselib::spgemm_estimate_memory(
+            handle, &alpha, a_descr, b_descr, &beta, c_descr, spgemm_descr,
+            spgemm_alg, 1.0f, buffer3_size, nullptr, nullptr);
+        array<char> buffer3{exec, buffer3_size};
+        sparselib::spgemm_estimate_memory(
+            handle, &alpha, a_descr, b_descr, &beta, c_descr, spgemm_descr,
+            spgemm_alg, 1.0f, buffer3_size, buffer3.get_data(), &buffer2_size);
+        buffer2.resize_and_reset(buffer2_size);
+        // compute spgemm
+        sparselib::spgemm_compute(
+            handle, &alpha, a_descr, b_descr, &beta, c_descr, spgemm_descr,
+            spgemm_alg, buffer1.get_data(), buffer2_size, buffer2.get_data());
+#else  // CUDA_VERSION < 12000
+        throw(cse);
+#endif
+    }
 
     // copy data to result
     auto c_nnz = sparselib::sparse_matrix_nnz(c_descr);
@@ -2534,7 +2572,7 @@ void spgemm(std::shared_ptr<const DefaultExecutor> exec,
                                 c_vals_array.get_data());
 
     sparselib::spgemm_copy(handle, &alpha, a_descr, b_descr, &beta, c_descr,
-                           spgemm_descr);
+                           spgemm_descr, spgemm_alg);
 
     sparselib::destroy(c_descr);
     sparselib::destroy(b_descr);
@@ -2673,25 +2711,66 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
         sparselib::create_csr(m, n, zero_nnz, c_tmp_row_ptrs_array.get_data(),
                               null_index, null_value);
 
-    // estimate work
-    size_type buffer1_size{};
-    sparselib::spgemm_work_estimation(handle, &one_val, a_descr, b_descr,
-                                      &zero_val, c_descr, spgemm_descr,
-                                      buffer1_size, nullptr);
-    array<char> buffer1{exec, buffer1_size};
-    sparselib::spgemm_work_estimation(handle, &one_val, a_descr, b_descr,
-                                      &zero_val, c_descr, spgemm_descr,
-                                      buffer1_size, buffer1.get_data());
+    auto spgemm_alg = CUSPARSE_SPGEMM_ALG1;
 
-    // compute spgemm
+    size_type buffer1_size{};
     size_type buffer2_size{};
-    sparselib::spgemm_compute(handle, &one_val, a_descr, b_descr, &zero_val,
-                              c_descr, spgemm_descr, buffer1.get_data(),
-                              buffer2_size, nullptr);
-    array<char> buffer2{exec, buffer2_size};
-    sparselib::spgemm_compute(handle, &one_val, a_descr, b_descr, &zero_val,
-                              c_descr, spgemm_descr, buffer1.get_data(),
-                              buffer2_size, buffer2.get_data());
+    array<char> buffer1{exec};
+    array<char> buffer2{exec};
+
+    // Try CUSPARSE_SPGEMM_ALG1 first as it is fastest for small matrices
+    try {
+        // Memory estimate for Alg1
+        sparselib::spgemm_work_estimation(handle, &one_val, a_descr, b_descr,
+                                          &zero_val, c_descr, spgemm_descr,
+                                          spgemm_alg, buffer1_size, nullptr);
+        buffer1.resize_and_reset(buffer1_size);
+        sparselib::spgemm_work_estimation(
+            handle, &one_val, a_descr, b_descr, &zero_val, c_descr,
+            spgemm_descr, spgemm_alg, buffer1_size, buffer1.get_data());
+        sparselib::spgemm_compute(handle, &one_val, a_descr, b_descr, &zero_val,
+                                  c_descr, spgemm_descr, spgemm_alg,
+                                  buffer1.get_data(), buffer2_size, nullptr);
+        // compute spgemm
+        buffer2.resize_and_reset(buffer2_size);
+        sparselib::spgemm_compute(handle, &one_val, a_descr, b_descr, &zero_val,
+                                  c_descr, spgemm_descr, spgemm_alg,
+                                  buffer1.get_data(), buffer2_size,
+                                  buffer2.get_data());
+    }
+
+    catch (const CusparseError& cse) {
+        // If estimated buffer size is too large and CUDA > 12.0,  fall back to
+        // ALG2
+#if CUDA_VERSION >= 12000
+        spgemm_alg = CUSPARSE_SPGEMM_ALG2;
+        // Memory estimate for Alg2/Alg3
+        sparselib::spgemm_work_estimation(handle, &one_val, a_descr, b_descr,
+                                          &zero_val, c_descr, spgemm_descr,
+                                          spgemm_alg, buffer1_size, nullptr);
+        buffer1.resize_and_reset(buffer1_size);
+        sparselib::spgemm_work_estimation(
+            handle, &one_val, a_descr, b_descr, &zero_val, c_descr,
+            spgemm_descr, spgemm_alg, buffer1_size, buffer1.get_data());
+        size_type buffer3_size{};
+        sparselib::spgemm_estimate_memory(
+            handle, &one_val, a_descr, b_descr, &zero_val, c_descr,
+            spgemm_descr, spgemm_alg, 1.0f, buffer3_size, nullptr, nullptr);
+        array<char> buffer3{exec, buffer3_size};
+        sparselib::spgemm_estimate_memory(handle, &one_val, a_descr, b_descr,
+                                          &zero_val, c_descr, spgemm_descr,
+                                          spgemm_alg, 1.0f, buffer3_size,
+                                          buffer3.get_data(), &buffer2_size);
+        buffer2.resize_and_reset(buffer2_size);
+        // compute spgemm
+        sparselib::spgemm_compute(handle, &one_val, a_descr, b_descr, &zero_val,
+                                  c_descr, spgemm_descr, spgemm_alg,
+                                  buffer1.get_data(), buffer2_size,
+                                  buffer2.get_data());
+#else  // CUDA_VERSION < 12000
+        throw(cse);
+#endif
+    }
 
     // write result to temporary storage
     auto c_tmp_nnz = sparselib::sparse_matrix_nnz(c_descr);
@@ -2702,7 +2781,7 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
                                 c_tmp_vals_array.get_data());
 
     sparselib::spgemm_copy(handle, &one_val, a_descr, b_descr, &zero_val,
-                           c_descr, spgemm_descr);
+                           c_descr, spgemm_descr, spgemm_alg);
 
     sparselib::destroy(c_descr);
     sparselib::destroy(b_descr);

--- a/common/cuda_hip/matrix/csr_kernels.template.cpp
+++ b/common/cuda_hip/matrix/csr_kernels.template.cpp
@@ -2534,9 +2534,9 @@ void spgemm(std::shared_ptr<const DefaultExecutor> exec,
 
     catch (const CusparseError& cse) {
         // If estimated buffer size is too large and CUDA > 12.0,  fall back to
-        // ALG2
+        // ALG3 with chunk fraction 0.1
 #if CUDA_VERSION >= 12000
-        spgemm_alg = CUSPARSE_SPGEMM_ALG2;
+        spgemm_alg = CUSPARSE_SPGEMM_ALG3;
         // Memory estimate for Alg2/Alg3
         sparselib::spgemm_work_estimation(handle, &alpha, a_descr, b_descr,
                                           &beta, c_descr, spgemm_descr,
@@ -2548,11 +2548,11 @@ void spgemm(std::shared_ptr<const DefaultExecutor> exec,
         size_type buffer3_size{};
         sparselib::spgemm_estimate_memory(
             handle, &alpha, a_descr, b_descr, &beta, c_descr, spgemm_descr,
-            spgemm_alg, 1.0f, buffer3_size, nullptr, nullptr);
+            spgemm_alg, 0.1f, buffer3_size, nullptr, nullptr);
         array<char> buffer3{exec, buffer3_size};
         sparselib::spgemm_estimate_memory(
             handle, &alpha, a_descr, b_descr, &beta, c_descr, spgemm_descr,
-            spgemm_alg, 1.0f, buffer3_size, buffer3.get_data(), &buffer2_size);
+            spgemm_alg, 0.1f, buffer3_size, buffer3.get_data(), &buffer2_size);
         buffer2.resize_and_reset(buffer2_size);
         // compute spgemm
         sparselib::spgemm_compute(
@@ -2741,7 +2741,7 @@ void advanced_spgemm(std::shared_ptr<const DefaultExecutor> exec,
 
     catch (const CusparseError& cse) {
         // If estimated buffer size is too large and CUDA > 12.0,  fall back to
-        // ALG2
+        // ALG3
 #if CUDA_VERSION >= 12000
         spgemm_alg = CUSPARSE_SPGEMM_ALG2;
         // Memory estimate for Alg2/Alg3

--- a/cuda/base/cusparse_bindings.hpp
+++ b/cuda/base/cusparse_bindings.hpp
@@ -208,13 +208,31 @@ void spgemm_work_estimation(cusparseHandle_t handle, const ValueType* alpha,
                             cusparseSpMatDescr_t b_descr, const ValueType* beta,
                             cusparseSpMatDescr_t c_descr,
                             cusparseSpGEMMDescr_t spgemm_descr,
+                            cusparseSpGEMMAlg_t spgemm_alg,
                             size_type& buffer1_size, void* buffer1)
 {
     GKO_ASSERT_NO_CUSPARSE_ERRORS(cusparseSpGEMM_workEstimation(
         handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
         CUSPARSE_OPERATION_NON_TRANSPOSE, alpha, a_descr, b_descr, beta,
-        c_descr, cuda_data_type<ValueType>(), CUSPARSE_SPGEMM_DEFAULT,
-        spgemm_descr, &buffer1_size, buffer1));
+        c_descr, cuda_data_type<ValueType>(), spgemm_alg, spgemm_descr,
+        &buffer1_size, buffer1));
+}
+
+template <typename ValueType>
+void spgemm_estimate_memory(cusparseHandle_t handle, const ValueType* alpha,
+                            cusparseSpMatDescr_t a_descr,
+                            cusparseSpMatDescr_t b_descr, const ValueType* beta,
+                            cusparseSpMatDescr_t c_descr,
+                            cusparseSpGEMMDescr_t spgemm_descr,
+                            cusparseSpGEMMAlg_t spgemm_alg,
+                            float chunk_fraction, size_type& buffer3_size,
+                            void* buffer3, size_type* buffer2_size)
+{
+    GKO_ASSERT_NO_CUSPARSE_ERRORS(cusparseSpGEMM_estimateMemory(
+        handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+        CUSPARSE_OPERATION_NON_TRANSPOSE, alpha, a_descr, b_descr, beta,
+        c_descr, cuda_data_type<ValueType>(), spgemm_alg, spgemm_descr,
+        chunk_fraction, &buffer3_size, buffer3, buffer2_size));
 }
 
 
@@ -222,14 +240,15 @@ template <typename ValueType>
 void spgemm_compute(cusparseHandle_t handle, const ValueType* alpha,
                     cusparseSpMatDescr_t a_descr, cusparseSpMatDescr_t b_descr,
                     const ValueType* beta, cusparseSpMatDescr_t c_descr,
-                    cusparseSpGEMMDescr_t spgemm_descr, void* buffer1,
+                    cusparseSpGEMMDescr_t spgemm_descr,
+                    cusparseSpGEMMAlg_t spgemm_alg, void* buffer1,
                     size_type& buffer2_size, void* buffer2)
 {
     GKO_ASSERT_NO_CUSPARSE_ERRORS(cusparseSpGEMM_compute(
         handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
         CUSPARSE_OPERATION_NON_TRANSPOSE, alpha, a_descr, b_descr, beta,
-        c_descr, cuda_data_type<ValueType>(), CUSPARSE_SPGEMM_DEFAULT,
-        spgemm_descr, &buffer2_size, buffer2));
+        c_descr, cuda_data_type<ValueType>(), spgemm_alg, spgemm_descr,
+        &buffer2_size, buffer2));
 }
 
 
@@ -237,13 +256,13 @@ template <typename ValueType>
 void spgemm_copy(cusparseHandle_t handle, const ValueType* alpha,
                  cusparseSpMatDescr_t a_descr, cusparseSpMatDescr_t b_descr,
                  const ValueType* beta, cusparseSpMatDescr_t c_descr,
-                 cusparseSpGEMMDescr_t spgemm_descr)
+                 cusparseSpGEMMDescr_t spgemm_descr,
+                 cusparseSpGEMMAlg_t spgemm_alg)
 {
-    GKO_ASSERT_NO_CUSPARSE_ERRORS(
-        cusparseSpGEMM_copy(handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
-                            CUSPARSE_OPERATION_NON_TRANSPOSE, alpha, a_descr,
-                            b_descr, beta, c_descr, cuda_data_type<ValueType>(),
-                            CUSPARSE_SPGEMM_DEFAULT, spgemm_descr));
+    GKO_ASSERT_NO_CUSPARSE_ERRORS(cusparseSpGEMM_copy(
+        handle, CUSPARSE_OPERATION_NON_TRANSPOSE,
+        CUSPARSE_OPERATION_NON_TRANSPOSE, alpha, a_descr, b_descr, beta,
+        c_descr, cuda_data_type<ValueType>(), spgemm_alg, spgemm_descr));
 }
 
 


### PR DESCRIPTION
If cuda spgemm fails using the default algorithm due to an out of memory issue, these changes add a fallback to ALG3, which performs the matrix multiplication in chunks. The default chunk fraction is set to 0.1, which should be enough to handle our current applications, but may need to eventually be changed to calculate the chunk fraction on the fly using available device memory.